### PR TITLE
fix: Splash 앱 진입 시만 뜨게 변경 + uri Link fix

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,7 +10,6 @@ import { Outlet, Route, Routes } from "react-router-dom";
 import MyProfile from "./pages/MyProfile/MyProfile";
 import CreateMentos from "./pages/Mentor/CreateMentos";
 import Home from "./pages/Home/Home";
-import SplashGate from "./pages/Home/SplashGate";
 import CommonHeader from "./components/common/CommonHeader";
 import MainHeader from "./components/main/mainHeader/MainHeader";
 import Login from "./pages/Login/Login";
@@ -26,14 +25,10 @@ const layoutStyle = "mx-auto min-h-screen w-full max-w-100 rounded-xl bg-white";
 function HomeLayout() {
   return (
     <div className={layoutStyle}>
-      <SplashGate>
-        <>
-          <MainHeader />
-          <main>
-            <Outlet />
-          </main>
-        </>
-      </SplashGate>
+      <MainHeader />
+      <main>
+        <Outlet />
+      </main>
     </div>
   );
 }

--- a/src/components/main/loginBox/MentoLoginBox.jsx
+++ b/src/components/main/loginBox/MentoLoginBox.jsx
@@ -23,7 +23,7 @@ function MentoLoginBox({ userName, userProfileImage }) {
 
       <button
         className="mx-auto cursor-pointer rounded-full bg-[#005EF9] p-2 px-6 text-sm font-semibold text-white hover:bg-[#0C2D62] hover:shadow"
-        onClick={() => navigate("/myprofile")}>
+        onClick={() => navigate("/mento")}>
         내 정보수정
       </button>
     </div>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,11 +3,14 @@ import ReactDOM from "react-dom/client";
 import "./index.css";
 import App from "./App.jsx";
 import { BrowserRouter } from "react-router-dom";
+import SplashGate from "./pages/Home/SplashGate";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <BrowserRouter basename="/memento-finance">
-      <App />
-    </BrowserRouter>
+    <SplashGate>
+      <BrowserRouter basename="/memento-finance">
+        <App />
+      </BrowserRouter>
+    </SplashGate>
   </React.StrictMode>,
 );

--- a/src/pages/Chat/ChatRoomPage.jsx
+++ b/src/pages/Chat/ChatRoomPage.jsx
@@ -1,4 +1,3 @@
-// src/pages/Chat/ChatRoomPage.jsx
 import { useEffect, useRef, useState } from "react";
 import { useParams } from "react-router-dom";
 import { Send } from "lucide-react";


### PR DESCRIPTION
## #️⃣ Issue Number


## 📝 요약(Summary)

1. 앱 진입 시( http://localhost:3000/memento-finance 진입 시)만 Splash 띄우게 변경
2. 멘토 내 정보 수정 연결 링크 변경

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] console.log(), alert()등의 코드를 제거했습니다.
- [ ] 동작 확인했습니다.
