### PR TITLE
feat: 결제하기(상세 내용) 모달 구현 및 전체 모달 위치 조정

### DIFF
--- a/src/components/common/CommonHeader.jsx
+++ b/src/components/common/CommonHeader.jsx
@@ -2,20 +2,32 @@ import loginIcon from "@/assets/images/login-icon.svg";
 import homeIcon from "@/assets/images/move-home-icon.svg";
 import backIcon from "@/assets/icons/backIcon.png";
 import PropTypes from "prop-types";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 
 export default function CommonHeader({ onClickLogin, onClickHome }) {
   const navigate = useNavigate();
+  const location = useLocation();
+
+  const handleBack = () => {
+    const isMyMentos = location.pathname.startsWith("/mentee/mymentos");
+    const fromPaySuccess = location.state?.fromPaymentSuccess;
+
+    if (isMyMentos && fromPaySuccess) {
+      // 결제 완료 → 나의 멘토스 내역에서만 홈으로
+      navigate("/", { replace: true, state: null });
+    } else {
+      navigate(-1);
+    }
+  };
 
   return (
     <header className="sticky top-0 z-50 flex items-center justify-between bg-white px-4 py-3">
-      {/* 왼쪽 뒤로가기 아이콘 */}
-      <button>
+      {/* 왼쪽 뒤로가기 */}
+      <button type="button" onClick={handleBack} aria-label="go back">
         <img
           src={backIcon}
           alt="backIcon"
           className="mx-0 h-6 w-auto cursor-pointer hover:brightness-60"
-          onClick={() => navigate(-1)}
         />
       </button>
 

--- a/src/components/common/CommonModal.jsx
+++ b/src/components/common/CommonModal.jsx
@@ -76,7 +76,6 @@ export function CommonModal({ type, isOpen, onCancel, onConfirm, onSubmit, modal
           })}
         </div>
       </div>
-      const hande
     </div>
   );
   return createPortal(modal, document.body);

--- a/src/pages/MyProfile/MyMentosList.jsx
+++ b/src/pages/MyProfile/MyMentosList.jsx
@@ -5,11 +5,13 @@ import MentosMainTitleComponent from "@/components/mentos/MentosMainTitleCompone
 import { useModal } from "@/hooks/common/useModal";
 import { CommonModal } from "@/components/common/CommonModal";
 import Button from "@/components/common/Button";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 
 function MyMentosList({ role, ...props }) {
   const { isOpen, modalType, openModal, closeModal, modalData } = useModal();
   const navigate = useNavigate();
+  const location = useLocation();
+  const fromPayment = location.state?.fromPaymentSuccess === true;
 
   const handleConfirmAction = () => {
     closeModal();
@@ -60,8 +62,8 @@ function MyMentosList({ role, ...props }) {
     openModal("reportMentos", { title: "신고하기" });
   };
 
-  const onRefundClick = () => {
-    openModal("refundMentos");
+  const onRefundClick = (mentosId) => {
+    openModal("refundMentos", { mentosId });
   };
 
   if (role === "mento") {
@@ -154,14 +156,14 @@ function MyMentosList({ role, ...props }) {
           price={50000}
           location="연남동"
           status="pending"
-          onRefundClick={onRefundClick}
+          onRefundClick={() => onRefundClick(101)}
         />
         <MentosCard
           title="React 강의"
           price={50000}
           location="연남동"
           status="pending"
-          onRefundClick={onRefundClick}
+          onRefundClick={() => onRefundClick(102)}
         />
       </section>
 

--- a/src/pages/book/BookingConfirm.tsx
+++ b/src/pages/book/BookingConfirm.tsx
@@ -44,13 +44,13 @@ export default function BookingConfirm() {
 
     if (!USE_REAL_TOSS) {
       navigate(`/booking/success?orderId=dummy-order&amount=${booking.price}`, {
-        state: { title: booking.title },
+        state: { title: booking.title, date: booking.date, time: booking.time },
         replace: true,
       });
       return;
     }
 
-    navigate("/book/payment", {
+    navigate("/booking/payment", {
       state: { ...booking, reservationSeq },
       replace: true,
     });

--- a/src/pages/book/PaySuccess.tsx
+++ b/src/pages/book/PaySuccess.tsx
@@ -1,17 +1,46 @@
-import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
+import { MODAL_CONFIG } from "@/utils/modal-config";
+import { useMemo, useState } from "react";
 import { CommonModal } from "@/components/common/CommonModal";
 
-export default function PaySuccess() {
-  const [open, setOpen] = useState(true);
-  const navigate = useNavigate();
+const weekdayKo = ["일", "월", "화", "수", "목", "금", "토"];
+const formatKoreanDate = (ymd?: string, time?: string) => {
+  if (!ymd) return "-";
+  const [y, m, d] = ymd.split("-").map(Number);
+  const dt = new Date(y, m - 1, d);
+  return `${m}.${d}(${weekdayKo[dt.getDay()]}) ${time ?? ""}`;
+};
 
-  const goToMyMentos = () => {
+export default function PaySuccess() {
+  const { search, state } = useLocation();
+  const navigate = useNavigate();
+  const params = new URLSearchParams(search);
+
+  const amount = Number(params.get("amount") || 0);
+  const title = state?.title ?? "멘토링";
+  const when = useMemo(
+    () => formatKoreanDate(state?.date, state?.time),
+    [state?.date, state?.time],
+  );
+  const line = `${title} · ${when} · ${amount.toLocaleString()}원 결제 완료!`;
+  MODAL_CONFIG.paySuccess.message = (
+    <div className="flex flex-col items-center gap-4 text-center">
+      <p className="font-WooridaumB text-lg">결제가 완료되었습니다</p>
+      <div className="w-full max-w-xs rounded-lg border border-gray-200 bg-gray-50 p-3">
+        <p className="font-WooridaumB text-base text-[#222939]">{title}</p>
+        <p className="font-WooridaumR text-sm text-[#287EFF]">{when}</p>
+        <p className="font-WooridaumR text-sm">{amount.toLocaleString()}원</p>
+      </div>
+    </div>
+  );
+
+  const [open, setOpen] = useState(true);
+  const goMyMentos = () => {
     setOpen(false);
-    navigate("/mentee/mymentos", { replace: true, state: { from: "paymentSuccess" } });
+    navigate("/mentee/mymentos", { replace: true, state: { fromPaymentSuccess: true } });
   };
 
   return (
-    <CommonModal type="paySuccess" isOpen={open} onConfirm={goToMyMentos} onCancel={goToMyMentos} />
+    <CommonModal type="paySuccess" isOpen={open} onConfirm={goMyMentos} onCancel={goMyMentos} />
   );
 }

--- a/src/utils/modal-config.jsx
+++ b/src/utils/modal-config.jsx
@@ -72,17 +72,14 @@ export const MODAL_CONFIG = {
       },
     ],
   },
-
   paySuccess: {
     icon: checkBlueIcon,
-    message: "결제가 완료되었습니다!",
     buttons: [
       {
-        text: "나의 멘토스 내역으로 이동",
+        text: "확인",
         variant: "primary",
         size: "lg",
         actionType: "close",
-        to: "/mentee/mymentos",
       },
     ],
   },


### PR DESCRIPTION
## #️⃣ Issue Number

#52 

## 📝 요약(Summary)

결제 완료 모달(paySuccess)에서 멘토링 이름 · 날짜/시간 · 결제 금액을 한 줄 메시지로 표시하도록 수정
기존 CommonModal 구조/스타일은 그대로 유지하고, PaySuccess.tsx에서 동적으로 메시지를 주입하도록 구현

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)
<img width="401" height="922" alt="image" src="https://github.com/user-attachments/assets/ccc9baeb-f6a6-47b2-8921-fc2b98ef88e2" />

## 💬 공유사항 to 리뷰어
CommonModal을 수정하지 않고 MODAL_CONFIG.paySuccess.message를 런타임에서 교체하는 방식으로 처리했는데, 이 접근 괜찮을지 확인 부탁드립니다.
혹시 메시지 포맷(멘토링 제목 · 날짜/시간 · 금액)을 다른 화면에서도 재사용할 수 있도록 util 함수로 분리하는 게 좋을지 확인 부탁드립니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] console.log(), alert()등의 코드를 제거했습니다.
- [x] 동작 확인했습니다.
