### PR TITLE
refactor: 멘토스 상세 소개 레이아웃 조정 및 멘토링 내역 타이틀 높이 통일

### DIFF
--- a/src/pages/Mentos/MentosDetail.jsx
+++ b/src/pages/Mentos/MentosDetail.jsx
@@ -102,8 +102,8 @@ function MentosDetail(props) {
       </section>
 
       <section className="flex w-full flex-col items-center justify-center gap-4 px-4 pt-[26%]">
-        <div className="relative flex w-full max-w-sm flex-col items-center justify-center rounded-[20px] bg-[#F4F4F4] p-4">
-          <div className="absolute -top-[26%] flex w-full">
+        <div className="mb- relative flex w-full max-w-sm flex-col items-center justify-center rounded-[20px] bg-[#F4F4F4] p-4">
+          <div className="absolute -top-[30%] flex w-full">
             <div className="relative flex w-full flex-col items-center justify-center">
               <span className="font-WooridaumB py-1 text-xl font-bold">멘토소개</span>
               <div className="z-10 h-auto w-[40%] overflow-hidden rounded-full bg-radial from-[white] via-[#E4EDFF] to-[#AEC8FF] p-1">

--- a/src/pages/MyProfile/MyMentosList.jsx
+++ b/src/pages/MyProfile/MyMentosList.jsx
@@ -133,7 +133,9 @@ function MyMentosList({ role, ...props }) {
 
   return (
     <div className="no-scrollbar flex h-full w-full min-w-[375px] flex-col gap-4 overflow-y-auto bg-white pb-4">
-      <MentosMainTitleComponent mainTitle={"나의 멘토링 내역"} />
+      <section className="px-4 py-5">
+        <MentosMainTitleComponent mainTitle="나의 멘토링 내역" />
+      </section>
       <section className="flex w-full flex-col items-center justify-center gap-3">
         <MentosCard
           title="React 강의"


### PR DESCRIPTION
## #️⃣ Issue Number

#53 

## 📝 요약 (Summary)

- 멘토스 상세 페이지의 멘토 소개 섹션 레이아웃을 조정했습니다.  
- 나의 멘토링 내역 페이지의 제목 위치를 멘토링 생성하기 화면을 기준으로 동일하게 맞췄습니다.  

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸 스크린샷 (선택)
<img width="397" height="897" alt="image" src="https://github.com/user-attachments/assets/9ab7e4ea-933b-4c02-83f3-d5f8eb84ac68" />
<img width="401" height="489" alt="image" src="https://github.com/user-attachments/assets/0553c73f-eab0-4fc9-b3d5-2cc4e515e791" />


## 💬 공유사항 to 리뷰어

- UI 정렬 관련해서 더 일관성 있는 공통 컴포넌트화가 필요할지 검토해주시면 좋겠습니다.  
- 현재는 padding/margin 값으로 맞췄는데, 전체적인 레이아웃 기준이 필요할지 의견 부탁드립니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지를 컨벤션에 맞게 작성했습니다.
- [x] `console.log()`, `alert()` 등의 디버깅 코드를 제거했습니다.
- [x] 동작을 확인했습니다.
